### PR TITLE
Update consent changed event handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/ban-ts-ignore": "warn",
+    "@typescript-eslint/no-empty-function": "off",
     "no-global-assign": "off",
     "@typescript-eslint/unbound-method": "warn"
   },

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _Hightouch works to ensure Consent Manager works with most of our product pipeli
 
 ### How it works
 
-1. The consent manager delays loading the events SDK until user consent is given, and will not load the SDK at all if the user opts out of everything. The user's tracking preferences are saved to a cookie and sent as an `identify` trait and a `Consent Updated` track event (if they haven't opted out of everything), ensuring consent data is propagated to your destinations.
+1. The consent manager delays loading the events SDK until user consent is given, and will not load the SDK at all if the user opts out of everything. The user's tracking preferences are saved to a cookie and sent as a `Consent Updated` track event (if they haven't opted out of everything), ensuring consent data is propagated to your destinations.
 
 2. **All** events will include the latest consent metadata inside the `context.consent` object:
 
@@ -43,29 +43,15 @@ _Hightouch works to ensure Consent Manager works with most of our product pipeli
    }
    ```
 
-3. Whenever a user updates their consent preferences, the following events will be emitted
-   - `identify` with updated preferences in `traits`
-     ```json
-     {
-       "type": "identify",
-       "traits": {
-         "destinationTrackingPreferences": {},
-         "categoryTrackingPreferences": {
-           "marketingAndAnalytics": true,
-           "advertising": true,
-           "functional": true
-         }
-       }
-     }
-     ```
+3. Whenever a user updates their consent preferences, the following event will be emitted
    - `track` named `Consent Updated` with updated preferences
      ```json
      {
        "type": "track",
        "event": "Consent Updated",
        "properties": {
-         "destinationTrackingPreferences": {},
-         "categoryTrackingPreferences": {
+         "destinationPreferences": {},
+         "categoryPreferences": {
            "marketingAndAnalytics": true,
            "advertising": true,
            "functional": true
@@ -784,7 +770,7 @@ Resets the [preferences][] state to the value saved in the cookie. Useful for re
 
 **Type**: `function(object|boolean)`
 
-Saves the preferences currently in state to a cookie called `ht-cm-preferences`, triggers an `identify` event with `destinationTrackingPreferences` and `categoryTrackingPreferences` traits, triggers a `track` event called `Consent Updated`, and then reloads the Browser SDK using the new preferences. It can also be passed preferences like [setPreferences][] to do a final update before saving.
+Saves the preferences currently in state to a cookie called `ht-cm-preferences`, triggers a `track` event named `Consent Updated`, and then reloads the Browser SDK using the new preferences. It can also be passed preferences like [setPreferences][] to do a final update before saving.
 
 ##### onError
 

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -172,7 +172,11 @@ describe('ConsentManagerBuilder', () => {
   test.skip('if defaultDestinationBehavior is set to imply and category is set to true, loads new destination', done => {
     document.cookie =
       'ht-cm-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:true%2C%22functional%22:true}}'
-    window.htevents = { load() {}, identify() {}, track() {}, addSourceMiddleware() {} }
+    window.htevents = {
+      load() {},
+      track() {},
+      addSourceMiddleware() {}
+    }
 
     nock('https://cdn.hightouch-events.com')
       .get('/v1/projects/123/integrations')
@@ -248,7 +252,6 @@ describe('ConsentManagerBuilder', () => {
       'ht-cm-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false%2C%22functional%22:true}}'
     window.htevents = {
       load() {},
-      identify() {},
       track() {},
       addSourceMiddleware() {}
     }

--- a/src/__tests__/consent-manager-builder/preferences.test.ts
+++ b/src/__tests__/consent-manager-builder/preferences.test.ts
@@ -53,7 +53,7 @@ describe('preferences', () => {
   })
 
   test('savePreferences() saves the preferences', () => {
-    const htevents = { identify: sinon.spy(), track: sinon.spy() }
+    const htevents = { track: sinon.spy() }
     ;(window as any).htevents = htevents
     document.cookie = ''
 
@@ -70,17 +70,11 @@ describe('preferences', () => {
       cookieDomain: undefined
     })
 
-    expect(htevents.identify.calledOnce).toBe(true)
-    expect(htevents.identify.args[0][0]).toMatchObject({
-      destinationTrackingPreferences: destinationPreferences,
-      categoryTrackingPreferences: customPreferences
-    })
-
     expect(htevents.track.calledOnce).toBe(true)
     expect(htevents.track.args[0][0]).toBe('Consent Updated')
     expect(htevents.track.args[0][1]).toMatchObject({
-      destinationTrackingPreferences: destinationPreferences,
-      categoryTrackingPreferences: customPreferences
+      destinationPreferences: destinationPreferences,
+      categoryPreferences: customPreferences
     })
 
     expect(
@@ -91,7 +85,7 @@ describe('preferences', () => {
   })
 
   test('savePreferences() sets the cookie domain', () => {
-    const htevents = { identify: sinon.spy(), track: sinon.spy() }
+    const htevents = { track: sinon.spy() }
     ;(window as any).htevents = htevents
     document.cookie = ''
 
@@ -105,17 +99,11 @@ describe('preferences', () => {
       cookieDomain: 'example.com'
     })
 
-    expect(htevents.identify.calledOnce).toBe(true)
-    expect(htevents.identify.args[0][0]).toMatchObject({
-      destinationTrackingPreferences: destinationPreferences,
-      categoryTrackingPreferences: undefined
-    })
-
     expect(htevents.track.calledOnce).toBe(true)
     expect(htevents.track.args[0][0]).toBe('Consent Updated')
     expect(htevents.track.args[0][1]).toMatchObject({
-      destinationTrackingPreferences: destinationPreferences,
-      categoryTrackingPreferences: undefined
+      destinationPreferences: destinationPreferences,
+      categoryPreferences: undefined
     })
 
     // TODO: actually check domain
@@ -123,7 +111,7 @@ describe('preferences', () => {
   })
 
   test('savePreferences() sets the cookie with custom key', () => {
-    const htevents = { identify: sinon.spy(), track: sinon.spy() }
+    const htevents = { track: sinon.spy() }
     ;(window as any).htevents = htevents
     document.cookie = ''
 
@@ -138,17 +126,11 @@ describe('preferences', () => {
       cookieName: 'custom-tracking-preferences'
     })
 
-    expect(htevents.identify.calledOnce).toBe(true)
-    expect(htevents.identify.args[0][0]).toMatchObject({
-      destinationTrackingPreferences: destinationPreferences,
-      categoryTrackingPreferences: undefined
-    })
-
     expect(htevents.track.calledOnce).toBe(true)
     expect(htevents.track.args[0][0]).toBe('Consent Updated')
     expect(htevents.track.args[0][1]).toMatchObject({
-      destinationTrackingPreferences: destinationPreferences,
-      categoryTrackingPreferences: undefined
+      destinationPreferences: destinationPreferences,
+      categoryPreferences: undefined
     })
 
     expect(document.cookie.includes('custom-tracking-preferences')).toBe(true)

--- a/src/__tests__/consent-manager-builder/preferences.test.ts
+++ b/src/__tests__/consent-manager-builder/preferences.test.ts
@@ -5,8 +5,26 @@ import {
   savePreferences,
   DEFAULT_COOKIE_NAME
 } from '../../consent-manager-builder/preferences'
+import { HtEventsBrowser } from '../../types'
 
 describe('preferences', () => {
+  let htevents: sinon.SinonStubbedInstance<Pick<HtEventsBrowser, 'track'>>
+
+  function expectConsentUpdatedEvent({ destinationPreferences, customPreferences }) {
+    expect(htevents.track.calledOnce).toBe(true)
+    expect(htevents.track.args[0][0]).toBe('Consent Updated')
+    expect(htevents.track.args[0][1]).toMatchObject({
+      destinationPreferences: destinationPreferences,
+      categoryPreferences: customPreferences
+    })
+    expect(htevents.track.args[0][2]).toMatchObject({
+      consent: {
+        destinationPreferences: destinationPreferences,
+        categoryPreferences: customPreferences
+      }
+    })
+  }
+
   beforeEach(() => {
     window = {
       location: {
@@ -23,6 +41,10 @@ describe('preferences', () => {
         return
       }
     } as Document
+    document.cookie = ''
+
+    htevents = sinon.stub({ track() {} })
+    ;(window as any).htevents = htevents
   })
 
   test('loadPreferences() returns preferences when cookie exists', () => {
@@ -53,13 +75,10 @@ describe('preferences', () => {
   })
 
   test('savePreferences() saves the preferences', () => {
-    const htevents = { track: sinon.spy() }
-    ;(window as any).htevents = htevents
-    document.cookie = ''
-
     const destinationPreferences = {
       Amplitude: true
     }
+
     const customPreferences = {
       functional: true
     }
@@ -70,69 +89,47 @@ describe('preferences', () => {
       cookieDomain: undefined
     })
 
-    expect(htevents.track.calledOnce).toBe(true)
-    expect(htevents.track.args[0][0]).toBe('Consent Updated')
-    expect(htevents.track.args[0][1]).toMatchObject({
-      destinationPreferences: destinationPreferences,
-      categoryPreferences: customPreferences
-    })
+    expectConsentUpdatedEvent({ destinationPreferences, customPreferences })
 
-    expect(
-      document.cookie.includes(
-        `${DEFAULT_COOKIE_NAME}={%22version%22:1%2C%22destination%22:{%22Amplitude%22:true}%2C%22custom%22:{%22functional%22:true}}`
-      )
-    ).toBe(true)
+    expect(document.cookie).toContain(
+      `${DEFAULT_COOKIE_NAME}={%22version%22:1%2C%22destination%22:{%22Amplitude%22:true}%2C%22custom%22:{%22functional%22:true}}`
+    )
   })
 
   test('savePreferences() sets the cookie domain', () => {
-    const htevents = { track: sinon.spy() }
-    ;(window as any).htevents = htevents
-    document.cookie = ''
-
     const destinationPreferences = {
       Amplitude: true
     }
 
+    const customPreferences = undefined
+
     savePreferences({
       destinationPreferences,
-      customPreferences: undefined,
+      customPreferences,
       cookieDomain: 'example.com'
     })
 
-    expect(htevents.track.calledOnce).toBe(true)
-    expect(htevents.track.args[0][0]).toBe('Consent Updated')
-    expect(htevents.track.args[0][1]).toMatchObject({
-      destinationPreferences: destinationPreferences,
-      categoryPreferences: undefined
-    })
+    expectConsentUpdatedEvent({ destinationPreferences, customPreferences })
 
-    // TODO: actually check domain
-    // expect(document.cookie.includes('domain=example.com')).toBe(true)
+    // ToDo: verify cookie domain is set (would need to mock js-cookie since document.cookie doesn't have domain info)
   })
 
   test('savePreferences() sets the cookie with custom key', () => {
-    const htevents = { track: sinon.spy() }
-    ;(window as any).htevents = htevents
-    document.cookie = ''
-
     const destinationPreferences = {
       Amplitude: true
     }
 
+    const customPreferences = undefined
+
     savePreferences({
       destinationPreferences,
-      customPreferences: undefined,
+      customPreferences,
       cookieDomain: undefined,
       cookieName: 'custom-tracking-preferences'
     })
 
-    expect(htevents.track.calledOnce).toBe(true)
-    expect(htevents.track.args[0][0]).toBe('Consent Updated')
-    expect(htevents.track.args[0][1]).toMatchObject({
-      destinationPreferences: destinationPreferences,
-      categoryPreferences: undefined
-    })
+    expectConsentUpdatedEvent({ destinationPreferences, customPreferences })
 
-    expect(document.cookie.includes('custom-tracking-preferences')).toBe(true)
+    expect(document.cookie).toContain('custom-tracking-preferences')
   })
 })

--- a/src/consent-manager-builder/analytics.ts
+++ b/src/consent-manager-builder/analytics.ts
@@ -28,7 +28,10 @@ function getConsentMiddleware(
     payload.obj.context.consent = {
       defaultDestinationBehavior,
       categoryPreferences,
-      destinationPreferences
+      destinationPreferences,
+      // give precedence to `context.consent` values set explicitly for the event
+      // this allows us to immediately reflect changes made to consent
+      ...payload.obj.context.consent
     }
     next(payload)
   }

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -64,17 +64,21 @@ export function savePreferences({
 }: SavePreferences) {
   const wd = window as WindowWithHtEvents
   if (wd.htevents) {
-    wd.htevents.identify({
-      destinationTrackingPreferences: destinationPreferences,
-      // use `categoryTrackingPreferences` here for consistency with `context.consent.categoryPreferences`
-      categoryTrackingPreferences: customPreferences
-    })
-
-    wd.htevents.track('Consent Updated', {
-      destinationTrackingPreferences: destinationPreferences,
-      // use `categoryTrackingPreferences` here for consistency with `context.consent.categoryPreferences`
-      categoryTrackingPreferences: customPreferences
-    })
+    wd.htevents.track(
+      'Consent Updated',
+      {
+        destinationPreferences,
+        // use `categoryPreferences` here for consistency with `context.consent.categoryPreferences`
+        categoryPreferences: customPreferences
+      },
+      {
+        // update `context.consent` here to immediately reflect the updated preferences
+        consent: {
+          destinationPreferences,
+          categoryPreferences: customPreferences
+        }
+      }
+    )
   } else {
     console.warn('window.htevents not found...is the SDK snippet included on the page?')
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export type HtEventsBrowserOptions = {
 export type HtEventsBrowser = {
   initialized: boolean
   load: (writeKey: string, options?: HtEventsBrowserOptions) => void
-  identify: (properties: Record<string, any>) => void
   track: (event: string, properties: Record<string, any>, options?: any, callback?: any) => void
   addSourceMiddleware: (middleware: Middleware) => void
 }


### PR DESCRIPTION
- Remove redundant `identify` event from being sent
- Use uniform property names (`destinationPreferences` + `categoryPreferences`) in event fields `context.consent` and `properties`
- Update consent middleware to respect `context.consent` set manually on `track` calls that way we can immediately update `context.consent` with latest user preferences (vs waiting for middleware to reload on next event)